### PR TITLE
uptime-monitor@v1.38.0

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.36.4
+        uses: upptime/uptime-monitor@v1.38.0
         with:
           command: "update"
         env:


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/uptime.yml` file. The change updates the version of the `upptime/uptime-monitor` action used for checking endpoint status.

* [`.github/workflows/uptime.yml`](diffhunk://#diff-26730d776a2baa21868e35d719dfc685ee306358fd8fb537f761c52bd5818324L35-R35): Updated `upptime/uptime-monitor` action from version `v1.36.4` to `v1.38.0`.