### PR TITLE
uptime-monitor@v1.38.0

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -13,7 +13,6 @@
 # * Docs and more: https://upptime.js.org
 # * More by Anand Chowdhary: https://anandchowdhary.com
 
-
 name: Graphs CI
 on:
   schedule:
@@ -32,7 +31,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.36.4
+        uses: upptime/uptime-monitor@v1.38.0
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -13,7 +13,6 @@
 # * Docs and more: https://upptime.js.org
 # * More by Anand Chowdhary: https://anandchowdhary.com
 
-
 name: Response Time CI
 on:
   schedule:
@@ -32,7 +31,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.36.4
+        uses: upptime/uptime-monitor@v1.38.0
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -13,7 +13,6 @@
 # * Docs and more: https://upptime.js.org
 # * More by Anand Chowdhary: https://anandchowdhary.com
 
-
 name: Setup CI
 on:
   push:
@@ -33,20 +32,20 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@v1.36.4
+        uses: upptime/uptime-monitor@v1.38.0
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.36.4
+        uses: upptime/uptime-monitor@v1.38.0
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.36.4
+        uses: upptime/uptime-monitor@v1.38.0
         with:
           command: "readme"
         env:
@@ -57,7 +56,7 @@ jobs:
           workflow: Graphs CI
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.36.4
+        uses: upptime/uptime-monitor@v1.38.0
         with:
           command: "site"
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.36.4
+        uses: upptime/uptime-monitor@v1.38.0
         with:
           command: "site"
         env:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -13,7 +13,6 @@
 # * Docs and more: https://upptime.js.org
 # * More by Anand Chowdhary: https://anandchowdhary.com
 
-
 name: Summary CI
 on:
   schedule:
@@ -32,7 +31,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.36.4
+        uses: upptime/uptime-monitor@v1.38.0
         with:
           command: "readme"
         env:


### PR DESCRIPTION
This pull request includes an update to the `upptime/uptime-monitor` action version in the GitHub Actions workflow configuration file. The action version has been updated from `v1.36.4` to `v1.38.0`.

* [`.github/workflows/site.yml`](diffhunk://#diff-8efa99d007eda5125986be411b0e5a7caab9ecd296af8e63e78f32b171bfb78eL36-R36): Updated the `upptime/uptime-monitor` action from version `v1.36.4` to `v1.38.0`.